### PR TITLE
Conform to latest Perl 6 module specs

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,0 +1,8 @@
+{
+    "name"        : "XXX",
+    "version"     : "*",
+    "description" : "See Your Data in the Nude",
+    "depends"     : [ "YAML" ],
+    "source-type" : "git",
+    "source-url"  : "git://github.com/ingydotnet/xxx-pm6.git"
+}


### PR DESCRIPTION
Ingy,

I added META.info in order to conform to latest Perl 6 module specs.  I also did this for yaml-pm6 and testml-pm6 as well as removing the outdated deps.proto file, but I pushed directly to those repos since I have a commit bit.  I still need to perform testing for these modules on the new Rakudo星, but this is a start.

Nick
