### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/XXX.pm
+++ b/lib/XXX.pm
@@ -1,4 +1,4 @@
-module XXX;
+unit module XXX;
 
 our $*VERSION = '0.01';
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
