### PR TITLE
Use kebab-case for test function names

### DIFF
--- a/t/ok.t
+++ b/t/ok.t
@@ -2,4 +2,4 @@ use Test;
 
 plan 1;
 
-eval_lives_ok 'use XXX; ', 'XXX modules loads without errors';
+eval-lives-ok 'use XXX; ', 'XXX modules loads without errors';


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of
kebab-case versions of the same names.  Thus `eval_lives_ok` becomes
`eval-lives-ok` as in this change.  This commit removes a deprecation
warning and allows the module to continue working after the 2015.09 Rakudo
release which will remove all deprecated features.
