### PR TITLE
Use kebab-case in test function names

### DIFF
--- a/t/ok.t
+++ b/t/ok.t
@@ -2,4 +2,4 @@ use Test;
 
 plan 1;
 
-eval_lives_ok 'use XXX; ', 'XXX modules loads without errors';
+eval-lives-ok 'use XXX; ', 'XXX modules loads without errors';


### PR DESCRIPTION
Test function names with underscores have been deprecated in favour of their
kebab-case variants. The deprecated form will be removed in Rakudo 2015.09.
This change brings the test suite up to date with current Rakudo.
